### PR TITLE
Add influx MCP server package

### DIFF
--- a/influx-mcp/.env.example
+++ b/influx-mcp/.env.example
@@ -1,0 +1,16 @@
+# InfluxDB common
+INFLUX_VERSION=auto
+INFLUX_URL=https://influx.example.com
+INFLUX_REQUEST_TIMEOUT_SEC=30
+MCP_LOG_LEVEL=INFO
+
+# InfluxDB v2
+INFLUX_ORG=my-org
+INFLUX_TOKEN=super-secret-token
+INFLUX_DEFAULT_BUCKET=sensors
+
+# InfluxDB v1
+INFLUX_USERNAME=admin
+INFLUX_PASSWORD=changeme
+INFLUX_DEFAULT_DB=iot
+INFLUX_DEFAULT_RP=autogen

--- a/influx-mcp/.gitignore
+++ b/influx-mcp/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/influx-mcp/README.md
+++ b/influx-mcp/README.md
@@ -1,0 +1,127 @@
+# influx-mcp
+
+Servidor [Model Context Protocol](https://spec.modelcontextprotocol.io/) para exponer consultas sobre clústeres InfluxDB v2 (Flux) e InfluxDB v1.x (InfluxQL) con un foco en datos de redes IoT.
+
+## Características
+
+- Autodetección opcional de versión del servidor (v2 o v1.x) o selección explícita mediante variables de entorno.
+- Registro de herramientas MCP para explorar buckets/databases, measurements, tags, fields y ejecutar consultas de series de tiempo con agregaciones y ventanas.
+- Namespace de recursos `influxdb://` que permite a un agente recuperar series de tiempo mediante URIs direccionables.
+- Respuestas validadas mediante modelos Pydantic y serializadas a JSON (con soporte opcional de previsualización tabular).
+- CLI `python -m influx_mcp.server` con modo `--dry-run` para validar la configuración y conectividad.
+
+## Instalación
+
+```bash
+pip install -e .
+```
+
+> **Nota:** el proyecto requiere Python 3.11 o superior.
+
+## Configuración
+
+Copie el archivo `.env.example` como base y complete los valores según su despliegue:
+
+```bash
+cp .env.example .env
+```
+
+Variables disponibles:
+
+| Variable | Descripción |
+| --- | --- |
+| `INFLUX_VERSION` | `2`, `1` o `auto` (default `auto`). |
+| `INFLUX_URL` | URL base del clúster (incluye protocolo y puerto). |
+| `INFLUX_ORG` | Organización para InfluxDB v2. |
+| `INFLUX_TOKEN` | Token de acceso v2. |
+| `INFLUX_DEFAULT_BUCKET` | Bucket por defecto (opcional). |
+| `INFLUX_USERNAME` | Usuario v1 (opcional si se deshabilitó auth). |
+| `INFLUX_PASSWORD` | Password v1. |
+| `INFLUX_DEFAULT_DB` | Base de datos por defecto v1.x. |
+| `INFLUX_DEFAULT_RP` | Retention policy por defecto v1.x. |
+| `INFLUX_REQUEST_TIMEOUT_SEC` | Timeout en segundos (default 30). |
+| `MCP_LOG_LEVEL` | Nivel de log (`INFO` por defecto). |
+
+## Ejecución
+
+```bash
+python -m influx_mcp.server
+```
+
+Parámetros CLI disponibles:
+
+- `--dry-run`: valida la configuración, intenta conectarse al servidor y muestra la versión detectada junto con los targets por defecto. No inicia el loop MCP.
+
+## Herramientas MCP
+
+Todas las herramientas retornan JSON con los campos descritos a continuación. Los modelos están documentados en `influx_mcp/schemas.py`.
+
+- `list_buckets_or_dbs()`
+  - Respuesta: lista de `{name, type, retention}`.
+- `list_measurements(target)`
+  - `target` corresponde a un bucket (v2) o `database[/retention_policy]` (v1).
+  - Respuesta: lista de `{name}`.
+- `list_fields(target, measurement)`
+  - Respuesta: lista `{name, type}` cuando está disponible.
+- `list_tags(target, measurement)`
+  - Respuesta: lista `{key, values}`.
+- `last_point(target, measurement, field?, tags?)`
+  - Respuesta: `{time_iso, value, field, tags}`.
+- `query_timeseries(...)`
+  - Parámetros: `target`, `measurement`, `field`, `start`, `stop?`, `tags?`, `aggregate?`, `every?`, `limit?`, `fill?`.
+  - Respuesta: `{series: [...], stats: {...}}` con los puntos y metadatos de la consulta.
+- `window_stats(target, measurement, field, window, tags?)`
+  - Calcula métricas agregadas (`mean`, `min`, `max`, `last`, `count`) en la ventana indicada.
+- `write_point(target, measurement, fields, tags?, time_iso?)` *(opcional, habilitada si el token/usuario tiene permisos de escritura)*.
+
+## Recursos MCP `influxdb://`
+
+- `read_resource(uri)`: ejecuta una consulta equivalente a `query_timeseries` en función de los parámetros de la URI y devuelve un texto con un encabezado descriptivo, una previsualización tabular y el JSON completo.
+- `list_resources()`: expone un número acotado de URIs sugeridas (p.ej. measurements populares del target por defecto) para facilitar la exploración guiada.
+
+Formato de URI:
+
+```
+influxdb://<target>/<measurement>?field=<field>&start=<iso_rel>&stop=<iso_rel>&every=<dur>&aggregate=<agg>&tag.device_id=abc
+```
+
+## Ejemplos de uso
+
+- Último nivel de batería:
+
+```json
+{
+  "tool": "last_point",
+  "params": {
+    "target": "sensors",
+    "measurement": "device_status",
+    "field": "battery",
+    "tags": {"device_id": "abc123"}
+  }
+}
+```
+
+- Serie agregada 24h (promedio cada 5 minutos):
+
+```json
+{
+  "tool": "query_timeseries",
+  "params": {
+    "target": "sensors",
+    "measurement": "env",
+    "field": "temperature",
+    "start": "-24h",
+    "every": "5m",
+    "aggregate": "mean",
+    "tags": {"site": "planta1"}
+  }
+}
+```
+
+## Pruebas
+
+```bash
+pytest
+```
+
+Los tests mockean el cliente Influx y validan el parseo de tiempos, URIs y contratos básicos de las herramientas.

--- a/influx-mcp/influx_mcp/__init__.py
+++ b/influx-mcp/influx_mcp/__init__.py
@@ -1,0 +1,7 @@
+"""influx_mcp package."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/influx-mcp/influx_mcp/client.py
+++ b/influx-mcp/influx_mcp/client.py
@@ -1,0 +1,449 @@
+"""InfluxDB client abstractions with auto-detection for v1/v2."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+from urllib.parse import urlparse
+
+from .config import AppConfig, ConfigError, InfluxV1Settings, InfluxV2Settings
+from .queries import (
+    BaseBackend,
+    QueryContext,
+    QueryEngine,
+    build_flux_fields_query,
+    build_flux_last_point_query,
+    build_flux_measurements_query,
+    build_flux_tag_keys_query,
+    build_flux_tag_values_query,
+    build_flux_timeseries_query,
+    build_influxql_field_keys_query,
+    build_influxql_last_point_query,
+    build_influxql_measurements_query,
+    build_influxql_tag_keys_query,
+    build_influxql_timeseries_query,
+)
+from .schemas import WritePointRequest
+
+try:  # pragma: no cover - optional dependency
+    from influxdb_client import InfluxDBClient
+    from influxdb_client.client.exceptions import InfluxDBError
+    from influxdb_client.client.write_api import SYNCHRONOUS as WRITE_SYNCHRONOUS
+except Exception:  # pragma: no cover - fallback when dependency missing
+    InfluxDBClient = None  # type: ignore[assignment]
+    InfluxDBError = Exception  # type: ignore[assignment]
+    WRITE_SYNCHRONOUS = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from influxdb import InfluxDBClient as InfluxDBClientV1
+except Exception:  # pragma: no cover - fallback when dependency missing
+    InfluxDBClientV1 = None  # type: ignore[assignment]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class InfluxClientError(RuntimeError):
+    """Base error for MCP client failures."""
+
+
+class InfluxConnectionError(InfluxClientError):
+    """Raised when the server cannot reach the Influx endpoint."""
+
+
+class InfluxClient:
+    """Facade that exposes the MCP query engine."""
+
+    def __init__(self, config: AppConfig) -> None:
+        self._config = config
+        self._mode = self._detect_mode(config)
+        if self._mode == "2":
+            settings = config.v2
+            if not settings:
+                raise ConfigError("InfluxDB v2 settings missing")
+            backend = _InfluxV2Backend(settings, timeout=config.request_timeout_sec)
+        else:
+            settings = config.v1
+            if not settings:
+                raise ConfigError("InfluxDB v1 settings missing")
+            backend = _InfluxV1Backend(settings, timeout=config.request_timeout_sec)
+        self.engine = QueryEngine(backend)
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def default_target(self) -> Optional[str]:
+        return self.engine.default_target
+
+    def close(self) -> None:
+        backend = self.engine._backend  # noqa: SLF001 - internal wiring
+        close_method = getattr(backend, "close", None)
+        if close_method:
+            close_method()
+
+    def _detect_mode(self, config: AppConfig) -> str:
+        if config.influx_version in {"1", "2"}:
+            _LOGGER.info("Using configured InfluxDB version %s", config.influx_version)
+            return config.influx_version
+        errors: List[str] = []
+        if config.v2:
+            try:
+                if _InfluxV2Backend.ping(config.v2, timeout=config.request_timeout_sec):
+                    _LOGGER.info("Detected InfluxDB v2 endpoint at %s", config.v2.url)
+                    return "2"
+            except Exception as exc:  # pragma: no cover - network dependent
+                errors.append(f"v2 detection failed: {exc}")
+        if config.v1:
+            try:
+                if _InfluxV1Backend.ping(config.v1, timeout=config.request_timeout_sec):
+                    _LOGGER.info("Detected InfluxDB v1 endpoint at %s", config.v1.url)
+                    return "1"
+            except Exception as exc:  # pragma: no cover - network dependent
+                errors.append(f"v1 detection failed: {exc}")
+        if errors:
+            _LOGGER.warning("; ".join(errors))
+        raise InfluxConnectionError("Could not detect InfluxDB version; set INFLUX_VERSION explicitly")
+
+
+@dataclass
+class _InfluxV2Backend(BaseBackend):
+    settings: InfluxV2Settings
+    timeout: int
+
+    mode: str = "2"
+
+    def __post_init__(self) -> None:
+        if InfluxDBClient is None:  # pragma: no cover - import guard
+            raise ImportError("influxdb-client package not installed")
+        self._client = InfluxDBClient(
+            url=self.settings.url,
+            token=self.settings.token,
+            org=self.settings.org,
+            timeout=self.timeout * 1000,
+        )
+        self._query = self._client.query_api()
+        self._write = self._client.write_api(write_options=WRITE_SYNCHRONOUS) if WRITE_SYNCHRONOUS else None
+
+    @property
+    def default_target(self) -> Optional[str]:
+        return self.settings.default_bucket
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        self._client.close()
+
+    @staticmethod
+    def ping(settings: InfluxV2Settings, *, timeout: int) -> bool:
+        if InfluxDBClient is None:  # pragma: no cover - import guard
+            raise ImportError("influxdb-client package not installed")
+        client = InfluxDBClient(url=settings.url, token=settings.token, org=settings.org, timeout=timeout * 1000)
+        try:
+            health = client.health()
+            return getattr(health, "status", "") == "pass"
+        finally:
+            client.close()
+
+    async def list_buckets_or_dbs(self) -> List[Mapping[str, str]]:
+        api = self._client.buckets_api()
+        buckets = api.find_buckets().buckets or []
+        items: List[Mapping[str, str]] = []
+        for bucket in buckets:
+            retention = None
+            if getattr(bucket, "retention_rules", None):
+                every = bucket.retention_rules[0].every_seconds
+                retention = "infinite" if every in (None, 0) else f"{every}s"
+            items.append({"name": bucket.name, "type": "bucket", "retention": retention})
+        return items
+
+    async def list_measurements(self, target: str) -> List[Mapping[str, str]]:
+        query = build_flux_measurements_query(target)
+        records = self._query.query(query, org=self.settings.org)
+        results: List[Mapping[str, str]] = []
+        for table in records:
+            for record in table.records:
+                results.append({"name": record.get_value()})
+        return results
+
+    async def list_fields(self, target: str, measurement: str) -> List[Mapping[str, str]]:
+        query = build_flux_fields_query(target, measurement)
+        tables = self._query.query(query, org=self.settings.org)
+        items: List[Mapping[str, str]] = []
+        for table in tables:
+            for record in table.records:
+                values = record.values
+                items.append({"name": values.get("_value"), "type": values.get("_fieldType")})
+        return items
+
+    async def list_tags(self, target: str, measurement: str) -> List[Mapping[str, Any]]:
+        tag_keys_query = build_flux_tag_keys_query(target, measurement)
+        tables = self._query.query(tag_keys_query, org=self.settings.org)
+        tag_keys = []
+        for table in tables:
+            for record in table.records:
+                tag_key = record.get_value()
+                tag_keys.append(tag_key)
+        results: List[Mapping[str, Any]] = []
+        for key in tag_keys:
+            values_query = build_flux_tag_values_query(target, measurement, key)
+            value_tables = self._query.query(values_query, org=self.settings.org)
+            values: List[str] = []
+            for value_table in value_tables:
+                for record in value_table.records:
+                    values.append(str(record.get_value()))
+            results.append({"key": key, "values": values})
+        return results
+
+    async def last_point(
+        self, target: str, measurement: str, field: Optional[str], tags: Mapping[str, str]
+    ) -> Mapping[str, Any]:
+        query = build_flux_last_point_query(target, measurement, field, tags)
+        tables = self._query.query(query, org=self.settings.org)
+        for table in tables:
+            for record in table.records:
+                values = record.values
+                time_iso = record.get_time().astimezone().isoformat()
+                tag_values = {k: v for k, v in values.items() if k not in {"_time", "_value", "_field", "_measurement"}}
+                return {
+                    "time_iso": time_iso,
+                    "value": record.get_value(),
+                    "field": values.get("_field"),
+                    "tags": tag_values,
+                }
+        raise InfluxClientError("No data available for last_point query")
+
+    async def query_timeseries(self, ctx: QueryContext) -> tuple[List[Mapping[str, Any]], Mapping[str, Any]]:
+        query = build_flux_timeseries_query(ctx)
+        tables = self._query.query(query, org=self.settings.org)
+        series: List[Mapping[str, Any]] = []
+        for table in tables:
+            for record in table.records:
+                time_iso = record.get_time().astimezone().isoformat()
+                series.append({"time_iso": time_iso, "value": record.get_value()})
+        stats = {
+            "points": len(series),
+            "start_eff": ctx.start_iso,
+            "stop_eff": ctx.stop_iso,
+            "aggregate": ctx.aggregate,
+            "every": ctx.every,
+        }
+        return series, stats
+
+    async def write_point(self, request: WritePointRequest) -> int:
+        if not self._write:
+            raise InfluxClientError("Write API not available without influxdb-client write options")
+        record = {
+            "measurement": request.measurement,
+            "tags": dict(request.tags or {}),
+            "fields": {key: value for key, value in request.fields.items() if value is not None},
+        }
+        if request.time_iso:
+            record["time"] = request.time_iso
+        self._write.write(bucket=request.target, record=record)
+        return 1
+
+    async def discover_resources(self, *, limit: int) -> List[Mapping[str, str]]:
+        bucket = self.settings.default_bucket
+        if not bucket:
+            return []
+        measurements = await self.list_measurements(bucket)
+        resources: List[Mapping[str, str]] = []
+        for measurement in measurements[:limit]:
+            uri = f"influxdb://{bucket}/{measurement['name']}?start=-1h"
+            resources.append({"uri": uri, "title": f"{measurement['name']} (última hora)"})
+        return resources
+
+
+@dataclass
+class _InfluxV1Backend(BaseBackend):
+    settings: InfluxV1Settings
+    timeout: int
+
+    mode: str = "1"
+
+    def __post_init__(self) -> None:
+        if InfluxDBClientV1 is None:  # pragma: no cover - import guard
+            raise ImportError("influxdb package not installed")
+        parsed = urlparse(self.settings.url)
+        ssl = parsed.scheme == "https"
+        host = parsed.hostname or "localhost"
+        port = parsed.port or (443 if ssl else 80)
+        self._client = InfluxDBClientV1(
+            host=host,
+            port=port,
+            username=self.settings.username,
+            password=self.settings.password,
+            database=self.settings.default_db,
+            ssl=ssl,
+            timeout=self.timeout,
+        )
+
+    @property
+    def default_target(self) -> Optional[str]:
+        if self.settings.default_db and self.settings.default_rp:
+            return f"{self.settings.default_db}/{self.settings.default_rp}"
+        return self.settings.default_db
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        self._client.close()
+
+    @staticmethod
+    def ping(settings: InfluxV1Settings, *, timeout: int) -> bool:
+        if InfluxDBClientV1 is None:  # pragma: no cover - import guard
+            raise ImportError("influxdb package not installed")
+        parsed = urlparse(settings.url)
+        ssl = parsed.scheme == "https"
+        host = parsed.hostname or "localhost"
+        port = parsed.port or (443 if ssl else 80)
+        client = InfluxDBClientV1(
+            host=host,
+            port=port,
+            username=settings.username,
+            password=settings.password,
+            database=settings.default_db,
+            ssl=ssl,
+            timeout=timeout,
+        )
+        try:
+            client.ping()
+            return True
+        finally:
+            client.close()
+
+    async def list_buckets_or_dbs(self) -> List[Mapping[str, str]]:
+        databases = self._client.get_list_database()
+        items: List[Mapping[str, str]] = []
+        for db in databases:
+            db_name = db.get("name")
+            items.append({"name": db_name, "type": "db", "retention": None})
+            rps = self._client.get_list_retention_policies(database=db_name)
+            for rp in rps:
+                retention = rp.get("duration")
+                items.append({"name": f"{db_name}/{rp['name']}", "type": "db", "retention": retention})
+        return items
+
+    async def list_measurements(self, target: str) -> List[Mapping[str, str]]:
+        db, rp = _split_target(target)
+        query = build_influxql_measurements_query(db, rp)
+        result = self._client.query(query, database=db)
+        return [{"name": point.get("name") } for point in result.get_points()]
+
+    async def list_fields(self, target: str, measurement: str) -> List[Mapping[str, str]]:
+        db, rp = _split_target(target)
+        query = build_influxql_field_keys_query(db, rp, measurement)
+        result = self._client.query(query, database=db)
+        items: List[Mapping[str, str]] = []
+        for point in result.get_points():
+            items.append({"name": point.get("fieldKey"), "type": point.get("fieldType")})
+        return items
+
+    async def list_tags(self, target: str, measurement: str) -> List[Mapping[str, Any]]:
+        db, rp = _split_target(target)
+        query = build_influxql_tag_keys_query(db, rp, measurement)
+        result = self._client.query(query, database=db)
+        tag_keys = [point.get("tagKey") for point in result.get_points()]
+        items: List[Mapping[str, Any]] = []
+        for key in tag_keys:
+            from_clause = f'"{measurement}"'
+            if rp:
+                from_clause = f'"{rp}"."{measurement}"'
+            values_query = f'SHOW TAG VALUES FROM {from_clause} WITH KEY = "{key}"'
+            values_result = self._client.query(values_query, database=db)
+            values = [point.get("value") for point in values_result.get_points()]
+            items.append({"key": key, "values": values})
+        return items
+
+    async def last_point(
+        self, target: str, measurement: str, field: Optional[str], tags: Mapping[str, str]
+    ) -> Mapping[str, Any]:
+        db, rp = _split_target(target)
+        query = build_influxql_last_point_query(db, rp, measurement, field, tags)
+        result = self._client.query(query, database=db)
+        points = list(result.get_points(measurement=measurement))
+        if not points:
+            raise InfluxClientError("No data available for last_point query")
+        point = points[0]
+        tags_out = {key: point.get(key) for key in tags.keys() if key in point}
+        if field:
+            value = point.get(field)
+        else:
+            value = {k: v for k, v in point.items() if k != "time"}
+        return {
+            "time_iso": point.get("time"),
+            "value": value,
+            "field": field,
+            "tags": tags_out,
+        }
+
+    async def query_timeseries(self, ctx: QueryContext) -> tuple[List[Mapping[str, Any]], Mapping[str, Any]]:
+        db, rp = _split_target(ctx.target)
+        query = build_influxql_timeseries_query(ctx, db, rp)
+        result = self._client.query(query, database=db)
+        series: List[Mapping[str, Any]] = []
+        for point in result.get_points():
+            value = point.get(ctx.field) if ctx.field else None
+            if value is None:
+                for key, val in point.items():
+                    if key != "time":
+                        value = val
+                        break
+            series.append({"time_iso": point.get("time"), "value": value})
+        stats = {
+            "points": len(series),
+            "start_eff": ctx.start_iso,
+            "stop_eff": ctx.stop_iso,
+            "aggregate": ctx.aggregate,
+            "every": ctx.every,
+        }
+        return series, stats
+
+    async def write_point(self, request: WritePointRequest) -> int:
+        db, rp = _split_target(request.target)
+        payload = [{
+            "measurement": request.measurement,
+            "tags": dict(request.tags or {}),
+            "fields": {key: value for key, value in request.fields.items() if value is not None},
+            "time": request.time_iso,
+        }]
+        success = self._client.write_points(payload, database=db, retention_policy=rp)
+        return 1 if success else 0
+
+    async def discover_resources(self, *, limit: int) -> List[Mapping[str, str]]:
+        target = self.default_target
+        if not target:
+            return []
+        measurements = await self.list_measurements(target)
+        resources: List[Mapping[str, str]] = []
+        for measurement in measurements[:limit]:
+            uri = f"influxdb://{target}/{measurement['name']}?start=-1h"
+            resources.append({"uri": uri, "title": f"{measurement['name']} (última hora)"})
+        return resources
+
+
+def _split_target(target: str) -> Tuple[str, Optional[str]]:
+    if "/" in target:
+        db, rp = target.split("/", 1)
+        return db, rp
+    return target, None
+
+
+async def dry_run(config: AppConfig) -> Dict[str, Any]:
+    """Validate connectivity without starting the MCP loop."""
+
+    client = InfluxClient(config)
+    try:
+        engine = client.engine
+        try:
+            await engine.list_buckets_or_dbs()
+            reachable = True
+        except Exception as exc:
+            _LOGGER.warning("Dry-run query failed: %s", exc)
+            reachable = False
+        return {
+            "version": client.mode,
+            "default_target": client.default_target,
+            "reachable": reachable,
+        }
+    finally:
+        client.close()

--- a/influx-mcp/influx_mcp/config.py
+++ b/influx-mcp/influx_mcp/config.py
@@ -1,0 +1,124 @@
+"""Environment configuration loading for influx_mcp."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping, Optional
+
+try:  # pragma: no cover - optional dependency shim
+    from pydantic import BaseModel, ConfigDict, Field, ValidationError
+except Exception:  # pragma: no cover - fallback minimal shim
+    from .schemas import BaseModel, ConfigDict, Field  # type: ignore[assignment]
+
+    class ValidationError(Exception):
+        pass
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration values are invalid."""
+
+
+class InfluxV2Settings(BaseModel):
+    url: str
+    org: str
+    token: str
+    default_bucket: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class InfluxV1Settings(BaseModel):
+    url: str
+    username: Optional[str] = None
+    password: Optional[str] = None
+    default_db: Optional[str] = None
+    default_rp: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AppConfig(BaseModel):
+    influx_version: str = Field(default="auto")
+    request_timeout_sec: int = Field(default=30, ge=1)
+    log_level: str = Field(default="INFO")
+    v2: Optional[InfluxV2Settings] = None
+    v1: Optional[InfluxV1Settings] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    value = value.strip()
+    return value if value else None
+
+
+def load_config(environ: Mapping[str, str] | None = None) -> AppConfig:
+    env = {key: value for key, value in (environ or os.environ).items() if value is not None}
+    version = _clean(env.get("INFLUX_VERSION")) or "auto"
+    if version not in {"1", "2", "auto"}:
+        raise ConfigError("INFLUX_VERSION must be one of '1', '2' or 'auto'")
+
+    log_level = _clean(env.get("MCP_LOG_LEVEL")) or "INFO"
+    timeout_raw = _clean(env.get("INFLUX_REQUEST_TIMEOUT_SEC"))
+    try:
+        timeout = int(timeout_raw) if timeout_raw else 30
+    except ValueError as exc:
+        raise ConfigError("INFLUX_REQUEST_TIMEOUT_SEC must be an integer") from exc
+
+    v2_settings: Optional[InfluxV2Settings] = None
+    v1_settings: Optional[InfluxV1Settings] = None
+
+    url = _clean(env.get("INFLUX_URL"))
+
+    if version in {"2", "auto"}:
+        org = _clean(env.get("INFLUX_ORG"))
+        token = _clean(env.get("INFLUX_TOKEN"))
+        if url and org and token:
+            try:
+                v2_settings = InfluxV2Settings(
+                    url=url,
+                    org=org,
+                    token=token,
+                    default_bucket=_clean(env.get("INFLUX_DEFAULT_BUCKET")),
+                )
+            except ValidationError as exc:  # pragma: no cover - validation depends on pydantic
+                raise ConfigError(str(exc)) from exc
+        elif version == "2":
+            raise ConfigError("INFLUX_URL, INFLUX_ORG and INFLUX_TOKEN are required for InfluxDB v2")
+
+    if version in {"1", "auto"}:
+        if url:
+            try:
+                v1_settings = InfluxV1Settings(
+                    url=url,
+                    username=_clean(env.get("INFLUX_USERNAME")),
+                    password=_clean(env.get("INFLUX_PASSWORD")),
+                    default_db=_clean(env.get("INFLUX_DEFAULT_DB")),
+                    default_rp=_clean(env.get("INFLUX_DEFAULT_RP")),
+                )
+            except ValidationError as exc:  # pragma: no cover
+                raise ConfigError(str(exc)) from exc
+        elif version == "1":
+            raise ConfigError("INFLUX_URL is required for InfluxDB v1")
+
+    if not v1_settings and not v2_settings:
+        raise ConfigError("No InfluxDB configuration found; set INFLUX_URL/ORG/TOKEN or credentials")
+
+    return AppConfig(
+        influx_version=version,
+        request_timeout_sec=timeout,
+        log_level=log_level,
+        v2=v2_settings,
+        v1=v1_settings,
+    )
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+    _LOGGER.debug("Logging configured to %s", level)

--- a/influx-mcp/influx_mcp/queries.py
+++ b/influx-mcp/influx_mcp/queries.py
@@ -1,0 +1,352 @@
+"""Query builders and orchestration for InfluxDB v2/v1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from . import schemas
+from .utils import ensure_limit, make_resource_text, normalize_tags, parse_duration, parse_influx_uri, resolve_time_range
+
+FLUX_AGG_MAP = {
+    "mean": "mean",
+    "max": "max",
+    "min": "min",
+    "sum": "sum",
+    "count": "count",
+    "median": "median",
+    "spread": "spread",
+    "last": "last",
+    "first": "first",
+}
+
+INFLUXQL_AGG_MAP = FLUX_AGG_MAP
+
+TAG_VALUE_LIMIT_DEFAULT = 20
+
+
+@dataclass
+class QueryContext:
+    target: str
+    measurement: str
+    field: Optional[str]
+    start_iso: str
+    stop_iso: str
+    tags: Dict[str, str]
+    aggregate: Optional[str]
+    every: Optional[str]
+    limit: Optional[int]
+    fill: Optional[str]
+
+
+def _flux_filter_expression(measurement: str, field: Optional[str], tags: Mapping[str, str]) -> str:
+    clauses: List[str] = [f'r["_measurement"] == "{measurement}"']
+    if field:
+        clauses.append(f'r["_field"] == "{field}"')
+    for key, value in tags.items():
+        clauses.append(f'r["{key}"] == "{value}"')
+    return " and ".join(clauses)
+
+
+def build_flux_measurements_query(bucket: str) -> str:
+    return f'import "influxdata/influxdb/schema"\nschema.measurements(bucket: "{bucket}")'
+
+
+def build_flux_fields_query(bucket: str, measurement: str) -> str:
+    return (
+        'import "influxdata/influxdb/schema"\n'
+        f'schema.fieldKeys(bucket: "{bucket}", predicate: (r) => r["_measurement"] == "{measurement}")'
+    )
+
+
+def build_flux_tag_keys_query(bucket: str, measurement: str) -> str:
+    return (
+        'import "influxdata/influxdb/schema"\n'
+        f'schema.tagKeys(bucket: "{bucket}", predicate: (r) => r["_measurement"] == "{measurement}")'
+    )
+
+
+def build_flux_tag_values_query(bucket: str, measurement: str, tag_key: str, *, value_limit: int = TAG_VALUE_LIMIT_DEFAULT) -> str:
+    return (
+        'import "influxdata/influxdb/schema"\n'
+        f'schema.tagValues(bucket: "{bucket}", predicate: (r) => r["_measurement"] == "{measurement}", tag: "{tag_key}")'
+        f'\n  |> limit(n: {value_limit})'
+    )
+
+
+def build_flux_last_point_query(bucket: str, measurement: str, field: Optional[str], tags: Mapping[str, str]) -> str:
+    filter_expr = _flux_filter_expression(measurement, field, tags)
+    return (
+        f'from(bucket: "{bucket}")\n'
+        '  |> range(start: time(v: "1970-01-01T00:00:00Z"))\n'
+        f'  |> filter(fn: (r) => {filter_expr})\n'
+        '  |> sort(columns: ["_time"], desc: true)\n'
+        '  |> limit(n: 1)'
+    )
+
+
+def build_flux_timeseries_query(ctx: QueryContext) -> str:
+    filter_expr = _flux_filter_expression(ctx.measurement, ctx.field, ctx.tags)
+    imports: List[str] = []
+    if ctx.fill == "linear":
+        imports.append('import "experimental"')
+    lines = [
+        f'from(bucket: "{ctx.target}")',
+        f'  |> range(start: time(v: "{ctx.start_iso}"), stop: time(v: "{ctx.stop_iso}"))',
+        f'  |> filter(fn: (r) => {filter_expr})',
+    ]
+    if ctx.aggregate and ctx.every:
+        flux_fn = FLUX_AGG_MAP[ctx.aggregate]
+        lines.append(f'  |> aggregateWindow(every: {ctx.every}, fn: {flux_fn}, createEmpty: false)')
+    elif ctx.aggregate:
+        flux_fn = FLUX_AGG_MAP[ctx.aggregate]
+        lines.append(f'  |> {flux_fn}()')
+    if ctx.fill == "prev":
+        lines.append('  |> fill(column: "_value", usePrevious: true)')
+    elif ctx.fill == "linear":
+        every = ctx.every or "1m"
+        lines.append(f'  |> experimental.interpolate.linear(every: {every})')
+    if ctx.limit:
+        lines.append(f'  |> limit(n: {ctx.limit})')
+    return ("\n".join(imports + lines)).strip()
+
+
+def build_influxql_measurements_query(db: str, rp: Optional[str]) -> str:
+    if rp:
+        return f'SHOW MEASUREMENTS ON "{db}" WITH MEASUREMENT =~ /.*/'
+    return f'SHOW MEASUREMENTS ON "{db}"'
+
+
+def build_influxql_field_keys_query(db: str, rp: Optional[str], measurement: str) -> str:
+    from_clause = f'"{measurement}"'
+    if rp:
+        from_clause = f'"{rp}"."{measurement}"'
+    return f'SHOW FIELD KEYS FROM {from_clause} ON "{db}"'
+
+
+def build_influxql_tag_keys_query(db: str, rp: Optional[str], measurement: str) -> str:
+    from_clause = f'"{measurement}"'
+    if rp:
+        from_clause = f'"{rp}"."{measurement}"'
+    return f'SHOW TAG KEYS FROM {from_clause} ON "{db}"'
+
+
+def build_influxql_last_point_query(db: str, rp: Optional[str], measurement: str, field: Optional[str], tags: Mapping[str, str]) -> str:
+    from_clause = f'"{measurement}"'
+    if rp:
+        from_clause = f'"{rp}"."{measurement}"'
+    select_field = "*" if not field else f'"{field}"'
+    where_parts = []
+    if tags:
+        for key, value in tags.items():
+            where_parts.append(f'"{key}" = \'{value}\'')
+    where_clause = " AND ".join(where_parts)
+    if where_clause:
+        where_clause = " WHERE " + where_clause
+    return (
+        f'SELECT {select_field} FROM {from_clause}{where_clause} ORDER BY time DESC LIMIT 1'
+    )
+
+
+def build_influxql_timeseries_query(ctx: QueryContext, db: str, rp: Optional[str]) -> str:
+    from_clause = f'"{ctx.measurement}"'
+    if rp:
+        from_clause = f'"{rp}"."{ctx.measurement}"'
+    field_expr = f'"{ctx.field}"' if ctx.field else '*'
+    where_parts = [
+        f'time >= \'{ctx.start_iso}\'',
+        f'time < \'{ctx.stop_iso}\'',
+    ]
+    for key, value in ctx.tags.items():
+        where_parts.append(f'"{key}" = \'{value}\'')
+    where_clause = " AND ".join(where_parts)
+    query = f'SELECT {field_expr} FROM {from_clause} WHERE {where_clause}'
+    if ctx.aggregate and ctx.every:
+        agg_fn = INFLUXQL_AGG_MAP[ctx.aggregate]
+        query = f'SELECT {agg_fn}({field_expr}) FROM {from_clause} WHERE {where_clause} GROUP BY time({ctx.every})'
+    elif ctx.aggregate:
+        agg_fn = INFLUXQL_AGG_MAP[ctx.aggregate]
+        query = f'SELECT {agg_fn}({field_expr}) FROM {from_clause} WHERE {where_clause}'
+    if ctx.aggregate and ctx.fill:
+        fill_clause = {
+            "none": "",
+            "prev": " fill(previous)",
+            "linear": " fill(linear)",
+        }[ctx.fill]
+        if fill_clause:
+            query = f"{query}{fill_clause}"
+    if ctx.limit:
+        query = f"{query} LIMIT {ctx.limit}"
+    return query
+
+
+class QueryEngine:
+    """High level façade used by the MCP tools."""
+
+    def __init__(self, backend: "BaseBackend") -> None:
+        self._backend = backend
+
+    @property
+    def default_target(self) -> Optional[str]:
+        return self._backend.default_target
+
+    @property
+    def mode(self) -> str:
+        return self._backend.mode
+
+    async def list_buckets_or_dbs(self) -> schemas.ListBucketsResponse:
+        records = await self._backend.list_buckets_or_dbs()
+        items = [schemas.BucketInfo(**record) for record in records]
+        return schemas.ListBucketsResponse(items=items)
+
+    async def list_measurements(self, target: str) -> schemas.ListMeasurementsResponse:
+        records = await self._backend.list_measurements(target)
+        items = [schemas.MeasurementInfo(**record) for record in records]
+        return schemas.ListMeasurementsResponse(items=items)
+
+    async def list_fields(self, target: str, measurement: str) -> schemas.ListFieldsResponse:
+        records = await self._backend.list_fields(target, measurement)
+        items = [schemas.FieldInfo(**record) for record in records]
+        return schemas.ListFieldsResponse(items=items)
+
+    async def list_tags(self, target: str, measurement: str) -> schemas.ListTagsResponse:
+        records = await self._backend.list_tags(target, measurement)
+        items = [schemas.TagInfo(**record) for record in records]
+        return schemas.ListTagsResponse(items=items)
+
+    async def last_point(
+        self, target: str, measurement: str, field: Optional[str], tags: Optional[Mapping[str, str]]
+    ) -> schemas.LastPointResponse:
+        record = await self._backend.last_point(target, measurement, field, normalize_tags(tags))
+        return schemas.LastPointResponse(**record)
+
+    async def query_timeseries(self, request: schemas.QueryTimeseriesRequest) -> schemas.QueryTimeseriesResponse:
+        start_dt, stop_dt = resolve_time_range(request.start, request.stop)
+        limit = ensure_limit(request.limit, default=None)
+        ctx = QueryContext(
+            target=request.target,
+            measurement=request.measurement,
+            field=request.field,
+            start_iso=start_dt.isoformat(),
+            stop_iso=stop_dt.isoformat(),
+            tags=normalize_tags(request.tags),
+            aggregate=request.aggregate,
+            every=request.every,
+            limit=limit,
+            fill=request.fill,
+        )
+        series, stats = await self._backend.query_timeseries(ctx)
+        points = [schemas.TimeseriesPoint(**point) for point in series]
+        stats_model = schemas.TimeseriesStats(**stats)
+        return schemas.QueryTimeseriesResponse(series=points, stats=stats_model)
+
+    async def window_stats(self, request: schemas.WindowStatsRequest) -> schemas.WindowStatsResponse:
+        duration = parse_duration(request.window)
+        stop_dt = datetime.now(UTC)
+        if duration.total_seconds() == 0:
+            raise ValueError("window duration must be non-zero")
+        start_dt = stop_dt - duration if duration.total_seconds() > 0 else stop_dt + duration
+        start_iso = start_dt.isoformat()
+        stop_iso = stop_dt.isoformat()
+        ctx = schemas.QueryTimeseriesRequest(
+            target=request.target,
+            measurement=request.measurement,
+            field=request.field,
+            start=start_iso,
+            stop=stop_iso,
+            tags=request.tags,
+            aggregate=None,
+            every=None,
+        )
+        response = await self.query_timeseries(ctx)
+        values: List[float] = []
+        for point in response.series:
+            try:
+                values.append(float(point.value))
+            except (TypeError, ValueError):
+                continue
+        mean_value = sum(values) / len(values) if values else None
+        min_value = min(values) if values else None
+        max_value = max(values) if values else None
+        last_value = response.series[-1].value if response.series else None
+        return schemas.WindowStatsResponse(
+            mean=mean_value,
+            min=min_value,
+            max=max_value,
+            last=last_value,
+            count=len(response.series),
+            start=start_iso,
+            stop=stop_iso,
+        )
+
+    async def write_point(self, request: schemas.WritePointRequest) -> schemas.WritePointResponse:
+        try:
+            written = await self._backend.write_point(request)
+        except NotImplementedError as exc:
+            raise RuntimeError("Write operations are not supported by this backend") from exc
+        return schemas.WritePointResponse(ok=written > 0, written=written)
+
+    async def read_resource(self, uri: str) -> str:
+        parsed = parse_influx_uri(uri)
+        request = schemas.QueryTimeseriesRequest(
+            target=parsed.target,
+            measurement=parsed.measurement,
+            field=parsed.field,
+            start=parsed.start or "-1h",
+            stop=parsed.stop,
+            tags=parsed.tags,
+            aggregate=parsed.aggregate,
+            every=parsed.every,
+            limit=parsed.limit,
+            fill=parsed.fill,
+        )
+        response = await self.query_timeseries(request)
+        summary = {
+            "target": request.target,
+            "measurement": request.measurement,
+            "field": request.field,
+            "start": response.stats.start_eff,
+            "stop": response.stats.stop_eff,
+            "aggregate": response.stats.aggregate,
+            "every": response.stats.every,
+        }
+        return make_resource_text(summary, (point.model_dump() for point in response.series))
+
+    async def list_resources(self, limit: int = 5) -> schemas.ListResourcesResponse:
+        items = await self._backend.discover_resources(limit=limit)
+        resources = [schemas.ResourceDescription(**item) for item in items]
+        return schemas.ListResourcesResponse(items=resources)
+
+
+class BaseBackend:
+    """Protocol-style base class for static type checking."""
+
+    mode: str
+    default_target: Optional[str]
+
+    async def list_buckets_or_dbs(self) -> List[Mapping[str, Any]]:  # pragma: no cover - interface definition
+        raise NotImplementedError
+
+    async def list_measurements(self, target: str) -> List[Mapping[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def list_fields(self, target: str, measurement: str) -> List[Mapping[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def list_tags(self, target: str, measurement: str) -> List[Mapping[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def last_point(
+        self, target: str, measurement: str, field: Optional[str], tags: Mapping[str, str]
+    ) -> Mapping[str, str]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def query_timeseries(self, ctx: QueryContext) -> tuple[List[Mapping[str, Any]], Mapping[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def write_point(self, request: schemas.WritePointRequest) -> int:  # pragma: no cover
+        raise NotImplementedError
+
+    async def discover_resources(self, *, limit: int) -> List[Mapping[str, Any]]:  # pragma: no cover
+        raise NotImplementedError

--- a/influx-mcp/influx_mcp/schemas.py
+++ b/influx-mcp/influx_mcp/schemas.py
@@ -1,0 +1,233 @@
+"""Pydantic models that describe tool inputs and outputs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Literal, Mapping, Optional
+
+try:  # pragma: no cover - optional dependency shim
+    from pydantic import BaseModel, Field, ConfigDict, field_validator
+except Exception:  # pragma: no cover - fallback for environments without pydantic
+    class BaseModel:  # type: ignore[override]
+        model_config: Dict[str, Any] = {}
+
+        def __init__(self, **data: Any) -> None:
+            for key, value in data.items():
+                setattr(self, key, value)
+
+        @classmethod
+        def model_validate(cls, data: Mapping[str, Any]) -> "BaseModel":
+            return cls(**dict(data))
+
+        def model_dump(self, **_: Any) -> Dict[str, Any]:
+            return {key: value for key, value in self.__dict__.items()}
+
+    def Field(default: Any = None, **_: Any) -> Any:  # type: ignore[override]
+        return default
+
+    def field_validator(*_args: Any, **_kwargs: Any):  # type: ignore[override]
+        def decorator(func):
+            return func
+
+        return decorator
+
+    class ConfigDict(dict):  # type: ignore[override]
+        pass
+
+
+class BucketInfo(BaseModel):
+    name: str
+    type: Literal["bucket", "db"]
+    retention: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListBucketsResponse(BaseModel):
+    items: List[BucketInfo]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MeasurementInfo(BaseModel):
+    name: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListMeasurementsResponse(BaseModel):
+    items: List[MeasurementInfo]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListMeasurementsRequest(BaseModel):
+    target: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class FieldInfo(BaseModel):
+    name: str
+    type: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListFieldsResponse(BaseModel):
+    items: List[FieldInfo]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListFieldsRequest(BaseModel):
+    target: str
+    measurement: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class TagInfo(BaseModel):
+    key: str
+    values: List[str]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListTagsResponse(BaseModel):
+    items: List[TagInfo]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListTagsRequest(BaseModel):
+    target: str
+    measurement: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class LastPointResponse(BaseModel):
+    time_iso: str
+    value: Any
+    field: Optional[str] = None
+    tags: Optional[Dict[str, Any]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class LastPointRequest(BaseModel):
+    target: str
+    measurement: str
+    field: Optional[str] = None
+    tags: Optional[Dict[str, Any]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class TimeseriesPoint(BaseModel):
+    time_iso: str
+    value: Any
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class TimeseriesStats(BaseModel):
+    points: int
+    start_eff: str
+    stop_eff: str
+    aggregate: Optional[str] = None
+    every: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class QueryTimeseriesResponse(BaseModel):
+    series: List[TimeseriesPoint]
+    stats: TimeseriesStats
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class QueryTimeseriesRequest(BaseModel):
+    target: str
+    measurement: str
+    field: Optional[str] = None
+    start: str
+    stop: Optional[str] = None
+    tags: Optional[Dict[str, Any]] = None
+    aggregate: Optional[str] = None
+    every: Optional[str] = None
+    limit: Optional[int] = Field(default=None, ge=1)
+    fill: Optional[Literal["none", "prev", "linear"]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("aggregate")
+    @classmethod
+    def _validate_aggregate(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        allowed = {"mean", "max", "min", "sum", "count", "median", "spread", "last", "first"}
+        if value not in allowed:
+            raise ValueError(f"aggregate must be one of {sorted(allowed)}")
+        return value
+
+
+class WindowStatsRequest(BaseModel):
+    target: str
+    measurement: str
+    field: str
+    window: str
+    tags: Optional[Dict[str, Any]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WindowStatsResponse(BaseModel):
+    mean: Optional[float]
+    min: Optional[float]
+    max: Optional[float]
+    last: Optional[Any]
+    count: int
+    start: str
+    stop: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WritePointRequest(BaseModel):
+    target: str
+    measurement: str
+    fields: Mapping[str, Any]
+    tags: Optional[Mapping[str, Any]] = None
+    time_iso: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WritePointResponse(BaseModel):
+    ok: bool
+    written: int
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ResourceDescription(BaseModel):
+    uri: str
+    title: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListResourcesResponse(BaseModel):
+    items: List[ResourceDescription]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DryRunResult(BaseModel):
+    version: str
+    default_target: Optional[str]
+    reachable: bool
+
+    model_config = ConfigDict(extra="forbid")

--- a/influx-mcp/influx_mcp/server.py
+++ b/influx-mcp/influx_mcp/server.py
@@ -1,0 +1,132 @@
+"""MCP server entry-point for InfluxDB queries."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from .client import InfluxClient, dry_run
+from .queries import QueryEngine
+from .config import AppConfig, ConfigError, configure_logging, load_config
+from .schemas import (
+    LastPointRequest,
+    QueryTimeseriesRequest,
+    WindowStatsRequest,
+    WritePointRequest,
+)
+from . import schemas
+
+try:  # pragma: no cover - optional dependency
+    from mcp.server.fastmcp import FastMCP
+except Exception:  # pragma: no cover - fallback placeholder
+    FastMCP = None  # type: ignore[assignment]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def build_app(engine: QueryEngine) -> Any:
+    if FastMCP is None:  # pragma: no cover - executed only without dependency
+        raise ImportError("mcp package is required to run the server")
+
+    app = FastMCP("influx-mcp")
+
+    @app.tool()
+    async def list_buckets_or_dbs() -> Dict[str, Any]:
+        response = await engine.list_buckets_or_dbs()
+        return response.model_dump()
+
+    @app.tool()
+    async def list_measurements(target: str) -> Dict[str, Any]:
+        request = schemas.ListMeasurementsRequest(target=target)
+        response = await engine.list_measurements(request.target)
+        return response.model_dump()
+
+    @app.tool()
+    async def list_fields(target: str, measurement: str) -> Dict[str, Any]:
+        request = schemas.ListFieldsRequest(target=target, measurement=measurement)
+        response = await engine.list_fields(request.target, request.measurement)
+        return response.model_dump()
+
+    @app.tool()
+    async def list_tags(target: str, measurement: str) -> Dict[str, Any]:
+        request = schemas.ListTagsRequest(target=target, measurement=measurement)
+        response = await engine.list_tags(request.target, request.measurement)
+        return response.model_dump()
+
+    @app.tool()
+    async def last_point(
+        target: str,
+        measurement: str,
+        field: Optional[str] = None,
+        tags: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        request = LastPointRequest(target=target, measurement=measurement, field=field, tags=tags)
+        response = await engine.last_point(request.target, request.measurement, request.field, request.tags)
+        return response.model_dump()
+
+    @app.tool()
+    async def query_timeseries(**params: Any) -> Dict[str, Any]:
+        request = QueryTimeseriesRequest.model_validate(params)
+        response = await engine.query_timeseries(request)
+        return response.model_dump()
+
+    @app.tool()
+    async def window_stats(**params: Any) -> Dict[str, Any]:
+        request = WindowStatsRequest.model_validate(params)
+        response = await engine.window_stats(request)
+        return response.model_dump()
+
+    @app.tool()
+    async def write_point(**params: Any) -> Dict[str, Any]:
+        request = WritePointRequest.model_validate(params)
+        response = await engine.write_point(request)
+        return response.model_dump()
+
+    @app.resource("influxdb://")
+    async def influx_resource(uri: str) -> str:
+        return await engine.read_resource(uri)
+
+    @app.list_resources("influxdb://")
+    async def influx_list_resources(limit: int = 5) -> Dict[str, Any]:
+        response = await engine.list_resources(limit=limit)
+        return response.model_dump()
+
+    return app
+
+
+def _load_and_prepare(argv: Optional[list[str]] = None) -> tuple[AppConfig, argparse.Namespace]:
+    parser = argparse.ArgumentParser(description="InfluxDB MCP server")
+    parser.add_argument("--dry-run", action="store_true", help="Valida la conexión y termina")
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config()
+    except ConfigError as exc:
+        parser.error(str(exc))
+    return config, args
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    config, args = _load_and_prepare(argv)
+    configure_logging(config.log_level)
+
+    if args.dry_run:
+        result = asyncio.run(dry_run(config))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    client = InfluxClient(config)
+    try:
+        app = build_app(client.engine)
+        _LOGGER.info("Starting MCP server (InfluxDB v%s)", client.mode)
+        app.run()
+    finally:
+        client.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/influx-mcp/influx_mcp/utils.py
+++ b/influx-mcp/influx_mcp/utils.py
@@ -1,0 +1,260 @@
+"""Utility helpers for influx_mcp."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Iterable, Mapping
+from urllib.parse import parse_qs, urlencode, urlparse
+
+try:  # pragma: no cover - optional dependency
+    from dateutil import parser as dateutil_parser
+except Exception:  # pragma: no cover - runtime fallback
+    dateutil_parser = None  # type: ignore[assignment]
+
+_LOGGER = logging.getLogger(__name__)
+
+_RELATIVE_PATTERN = re.compile(r"^(?P<sign>[+-]?)(?P<value>\d+)(?P<unit>[smhdw])$")
+_FILL_ALLOWED = {"none", "prev", "linear"}
+
+
+@dataclass(slots=True)
+class ParsedInfluxURI:
+    """Structured representation of an `influxdb://` URI."""
+
+    target: str
+    measurement: str
+    field: str | None = None
+    start: str | None = None
+    stop: str | None = None
+    every: str | None = None
+    aggregate: str | None = None
+    tags: dict[str, str] | None = None
+    limit: int | None = None
+    fill: str | None = None
+
+
+def mask_secret(value: str | None, visible: int = 2) -> str:
+    """Return a masked representation of a secret token for logging."""
+
+    if not value:
+        return ""
+    stripped = value.strip()
+    if len(stripped) <= visible:
+        return "*" * len(stripped)
+    return f"{stripped[:visible]}…{stripped[-visible:]}"
+
+
+def _ensure_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    if dateutil_parser is not None:  # pragma: no cover - exercised when dependency available
+        dt = dateutil_parser.isoparse(value)
+    else:
+        normalized = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+    return _ensure_datetime(dt)
+
+
+def _relative_to_timedelta(expression: str) -> timedelta:
+    match = _RELATIVE_PATTERN.match(expression)
+    if not match:
+        raise ValueError(f"Invalid relative duration: {expression}")
+    sign_token = match.group("sign")
+    if sign_token == "-":
+        sign = -1
+    else:
+        sign = 1
+    value = int(match.group("value"))
+    unit = match.group("unit")
+    factor = {
+        "s": 1,
+        "m": 60,
+        "h": 3600,
+        "d": 86400,
+        "w": 604800,
+    }[unit]
+    seconds = sign * value * factor
+    return timedelta(seconds=seconds)
+
+
+def parse_duration(value: str) -> timedelta:
+    """Parse duration strings like ``5m`` or ``-24h`` into ``timedelta``."""
+
+    value = value.strip()
+    delta = _relative_to_timedelta(value)
+    return delta
+
+
+def resolve_time_range(
+    start: str,
+    stop: str | None,
+    *,
+    now: datetime | None = None,
+) -> tuple[datetime, datetime]:
+    """Resolve start/stop values expressed as ISO 8601 or relative durations."""
+
+    now = _ensure_datetime(now or datetime.now(UTC))
+
+    def _parse(value: str) -> datetime:
+        value = value.strip()
+        if _RELATIVE_PATTERN.match(value):
+            delta = _relative_to_timedelta(value)
+            return now + delta
+        return _parse_iso_datetime(value)
+
+    start_dt = _parse(start)
+    stop_dt = _parse(stop) if stop else now
+    if start_dt >= stop_dt:
+        raise ValueError("start must be before stop")
+    return start_dt, stop_dt
+
+
+def ensure_limit(value: int | None, *, default: int | None = None, hard_cap: int = 50_000) -> int | None:
+    """Sanitise user-provided limits to avoid runaway queries."""
+
+    if value is None:
+        return default
+    if value <= 0:
+        raise ValueError("limit must be greater than zero")
+    if value > hard_cap:
+        _LOGGER.warning("Requested limit %s exceeds cap %s; truncating", value, hard_cap)
+        return hard_cap
+    return value
+
+
+def normalize_tags(tags: Mapping[str, Any] | None) -> dict[str, str]:
+    """Return a sanitized dictionary of tag filters."""
+
+    if not tags:
+        return {}
+    normalized: dict[str, str] = {}
+    for key, value in tags.items():
+        if value is None:
+            continue
+        normalized[str(key)] = str(value)
+    return normalized
+
+
+def format_preview_table(rows: Iterable[Mapping[str, Any]], *, limit: int = 10) -> str:
+    """Create a simple human readable table preview."""
+
+    rows_list = list(rows)
+    preview_rows = rows_list[:limit]
+    if not preview_rows:
+        return "<sin datos>"
+
+    headers = list(preview_rows[0].keys())
+    col_widths = []
+    for header in headers:
+        values = [str(header)]
+        values.extend(str(row.get(header, "")) for row in preview_rows)
+        col_widths.append(max(len(value) for value in values))
+    lines = []
+    header_line = " | ".join(header.ljust(width) for header, width in zip(headers, col_widths))
+    lines.append(header_line)
+    lines.append("-+-".join("-" * width for width in col_widths))
+    for row in preview_rows:
+        lines.append(" | ".join(str(row.get(header, "")).ljust(width) for header, width in zip(headers, col_widths)))
+    if len(rows_list) > limit:
+        lines.append("…")
+    return "\n".join(lines)
+
+
+def parse_influx_uri(uri: str) -> ParsedInfluxURI:
+    """Parse an ``influxdb://`` URI into its components."""
+
+    parsed = urlparse(uri)
+    if parsed.scheme != "influxdb":
+        raise ValueError("URI must start with influxdb://")
+    if not parsed.path or parsed.path == "/":
+        raise ValueError("URI must include a measurement name")
+    target = parsed.netloc
+    measurement = parsed.path.lstrip("/")
+    params = parse_qs(parsed.query, keep_blank_values=False)
+
+    tags: dict[str, str] = {}
+    other: dict[str, str] = {}
+    for key, values in params.items():
+        value = values[0]
+        if key.startswith("tag."):
+            tags[key[4:]] = value
+        else:
+            other[key] = value
+
+    limit = int(other["limit"]) if "limit" in other else None
+    fill = other.get("fill")
+    if fill and fill not in _FILL_ALLOWED:
+        raise ValueError(f"Invalid fill strategy: {fill}")
+
+    return ParsedInfluxURI(
+        target=target,
+        measurement=measurement,
+        field=other.get("field"),
+        start=other.get("start"),
+        stop=other.get("stop"),
+        every=other.get("every"),
+        aggregate=other.get("aggregate"),
+        tags=tags or None,
+        limit=limit,
+        fill=fill,
+    )
+
+
+def build_influx_uri(params: ParsedInfluxURI) -> str:
+    """Create a canonical URI from :class:`ParsedInfluxURI`."""
+
+    query: dict[str, str] = {}
+    if params.field:
+        query["field"] = params.field
+    if params.start:
+        query["start"] = params.start
+    if params.stop:
+        query["stop"] = params.stop
+    if params.every:
+        query["every"] = params.every
+    if params.aggregate:
+        query["aggregate"] = params.aggregate
+    if params.limit is not None:
+        query["limit"] = str(params.limit)
+    if params.fill:
+        query["fill"] = params.fill
+    if params.tags:
+        for key, value in params.tags.items():
+            query[f"tag.{key}"] = value
+    encoded = urlencode(query)
+    path = f"/{params.measurement}" if not params.measurement.startswith("/") else params.measurement
+    return f"influxdb://{params.target}{path}{('?' + encoded) if encoded else ''}"
+
+
+def make_resource_text(summary: Mapping[str, Any], series: Iterable[Mapping[str, Any]]) -> str:
+    """Format resource output with summary and JSON appendix."""
+
+    preview = format_preview_table(series)
+    json_payload = json.dumps(summary, indent=2, ensure_ascii=False)
+    return (
+        "Consulta InfluxDB\n"
+        f"Target: {summary.get('target')}\n"
+        f"Measurement: {summary.get('measurement')}\n"
+        f"Field: {summary.get('field')}\n"
+        f"Ventana: {summary.get('start')} → {summary.get('stop')}\n\n"
+        "Previsualización:\n"
+        f"{preview}\n\n"
+        "JSON completo:\n"
+        f"{json_payload}\n"
+    )
+
+
+def mean(values: Iterable[float]) -> float:
+    data = list(values)
+    if not data:
+        return math.nan
+    return sum(data) / len(data)

--- a/influx-mcp/mcp.json
+++ b/influx-mcp/mcp.json
@@ -1,0 +1,18 @@
+{
+  "name": "influx-mcp",
+  "description": "MCP server para consultar InfluxDB (v2/v1) con herramientas IoT",
+  "command": ["python", "-m", "influx_mcp.server"],
+  "env": [
+    "INFLUX_VERSION",
+    "INFLUX_URL",
+    "INFLUX_ORG",
+    "INFLUX_TOKEN",
+    "INFLUX_DEFAULT_BUCKET",
+    "INFLUX_USERNAME",
+    "INFLUX_PASSWORD",
+    "INFLUX_DEFAULT_DB",
+    "INFLUX_DEFAULT_RP",
+    "INFLUX_REQUEST_TIMEOUT_SEC",
+    "MCP_LOG_LEVEL"
+  ]
+}

--- a/influx-mcp/pyproject.toml
+++ b/influx-mcp/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "influx-mcp"
+version = "0.1.0"
+description = "MCP server for querying InfluxDB time series data"
+readme = "README.md"
+authors = [{name = "Respo Codex", email = "devnull@example.com"}]
+requires-python = ">=3.11"
+license = {text = "MIT"}
+dependencies = [
+    "mcp>=0.1.0",
+    "influxdb-client>=1.43.0",
+    "influxdb>=5.3.2",
+    "pydantic>=2.5",
+    "python-dateutil>=2.8.2",
+]
+
+[project.optional-dependencies]
+formatting = ["pandas>=2.2.0"]
+dev = [
+    "pytest>=7.4",
+]
+
+[project.urls]
+Homepage = "https://example.com/influx-mcp"
+
+[tool.setuptools.package-data]
+influx_mcp = ["py.typed"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = ["tests"]

--- a/influx-mcp/pytest.ini
+++ b/influx-mcp/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+pythonpath = .

--- a/influx-mcp/tests/test_config.py
+++ b/influx-mcp/tests/test_config.py
@@ -1,0 +1,42 @@
+import pytest
+
+from influx_mcp.config import ConfigError, load_config
+
+
+def test_load_config_v2_only():
+    env = {
+        "INFLUX_VERSION": "2",
+        "INFLUX_URL": "https://example.com",
+        "INFLUX_ORG": "iot",
+        "INFLUX_TOKEN": "token",
+        "MCP_LOG_LEVEL": "debug",
+    }
+    config = load_config(env)
+    assert config.v2 is not None
+    assert config.v2.url == "https://example.com"
+    assert config.influx_version == "2"
+    assert config.log_level.lower() == "debug"
+
+
+def test_load_config_v1_auto_defaults():
+    env = {
+        "INFLUX_URL": "http://localhost:8086",
+        "INFLUX_USERNAME": "user",
+        "INFLUX_PASSWORD": "pass",
+        "INFLUX_DEFAULT_DB": "sensors",
+    }
+    config = load_config(env)
+    assert config.v1 is not None
+    assert config.v1.default_db == "sensors"
+    assert config.influx_version == "auto"
+
+
+def test_load_config_requires_values():
+    env = {"INFLUX_VERSION": "2", "INFLUX_URL": "https://example.com"}
+    with pytest.raises(ConfigError):
+        load_config(env)
+
+
+def test_invalid_version():
+    with pytest.raises(ConfigError):
+        load_config({"INFLUX_VERSION": "five"})

--- a/influx-mcp/tests/test_config.py
+++ b/influx-mcp/tests/test_config.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # required for pytest.raises usage
 
 from influx_mcp.config import ConfigError, load_config
 

--- a/influx-mcp/tests/test_parsing.py
+++ b/influx-mcp/tests/test_parsing.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from influx_mcp.utils import build_influx_uri, ensure_limit, make_resource_text, parse_duration, parse_influx_uri, resolve_time_range
+
+
+def test_parse_influx_uri_basic():
+    uri = "influxdb://bucket/measurement?field=temp&start=-1h&aggregate=mean&tag.device=abc"
+    parsed = parse_influx_uri(uri)
+    assert parsed.target == "bucket"
+    assert parsed.measurement == "measurement"
+    assert parsed.field == "temp"
+    assert parsed.aggregate == "mean"
+    assert parsed.tags == {"device": "abc"}
+    rebuilt = build_influx_uri(parsed)
+    assert rebuilt.startswith("influxdb://bucket/measurement")
+
+
+def test_resolve_time_range_relative():
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+    start, stop = resolve_time_range("-1h", None, now=now)
+    assert stop == now
+    assert stop - start == timedelta(hours=1)
+
+
+def test_parse_duration_positive_negative():
+    assert parse_duration("15m") == timedelta(minutes=15)
+    assert parse_duration("-2h") == timedelta(hours=-2)
+
+
+def test_ensure_limit_cap_warning():
+    assert ensure_limit(10, hard_cap=50) == 10
+    assert ensure_limit(100, hard_cap=50) == 50
+    with pytest.raises(ValueError):
+        ensure_limit(0)
+
+
+def test_make_resource_text_format():
+    summary = {"target": "bucket", "measurement": "m", "field": "f", "start": "s", "stop": "e"}
+    text = make_resource_text(summary, [{"time_iso": "t", "value": 1}])
+    assert "bucket" in text
+    assert "time_iso" in text

--- a/influx-mcp/tests/test_tools_smoke.py
+++ b/influx-mcp/tests/test_tools_smoke.py
@@ -1,0 +1,103 @@
+import asyncio
+
+from influx_mcp.queries import BaseBackend, QueryContext, QueryEngine
+from influx_mcp.schemas import QueryTimeseriesRequest, WindowStatsRequest, WritePointRequest
+
+
+class FakeBackend(BaseBackend):
+    mode = "2"
+    default_target = "sensors"
+
+    def __init__(self) -> None:
+        self.last_write: WritePointRequest | None = None
+
+    async def list_buckets_or_dbs(self):
+        return [{"name": "sensors", "type": "bucket", "retention": "infinite"}]
+
+    async def list_measurements(self, target: str):
+        assert target == "sensors"
+        return [{"name": "env"}]
+
+    async def list_fields(self, target: str, measurement: str):
+        return [{"name": "temperature", "type": "float"}]
+
+    async def list_tags(self, target: str, measurement: str):
+        return [{"key": "device_id", "values": ["abc"]}]
+
+    async def last_point(self, target: str, measurement: str, field, tags):
+        return {
+            "time_iso": "2024-01-01T00:00:00+00:00",
+            "value": 21.5,
+            "field": field or "temperature",
+            "tags": tags,
+        }
+
+    async def query_timeseries(self, ctx: QueryContext):
+        series = [
+            {"time_iso": ctx.start_iso, "value": 1.0},
+            {"time_iso": ctx.stop_iso, "value": 2.0},
+        ]
+        stats = {
+            "points": len(series),
+            "start_eff": ctx.start_iso,
+            "stop_eff": ctx.stop_iso,
+            "aggregate": ctx.aggregate,
+            "every": ctx.every,
+        }
+        return series, stats
+
+    async def write_point(self, request: WritePointRequest) -> int:
+        self.last_write = request
+        return 1
+
+    async def discover_resources(self, *, limit: int):
+        return [{"uri": "influxdb://sensors/env?start=-1h", "title": "env (1h)"}]
+
+def test_engine_endpoints():
+    backend = FakeBackend()
+    engine = QueryEngine(backend)
+
+    buckets = asyncio_run(engine.list_buckets_or_dbs())
+    assert buckets.items[0].name == "sensors"
+
+    measurements = asyncio_run(engine.list_measurements("sensors"))
+    assert measurements.items[0].name == "env"
+
+    fields = asyncio_run(engine.list_fields("sensors", "env"))
+    assert fields.items[0].name == "temperature"
+
+    tags = asyncio_run(engine.list_tags("sensors", "env"))
+    assert tags.items[0].key == "device_id"
+
+    last = asyncio_run(engine.last_point("sensors", "env", "temperature", {"device_id": "abc"}))
+    assert last.value == 21.5
+
+    timeseries_request = QueryTimeseriesRequest(
+        target="sensors",
+        measurement="env",
+        field="temperature",
+        start="-1h",
+    )
+    series = asyncio_run(engine.query_timeseries(timeseries_request))
+    assert series.stats.points == 2
+
+    window_response = asyncio_run(
+        engine.window_stats(WindowStatsRequest(target="sensors", measurement="env", field="temperature", window="1h"))
+    )
+    assert window_response.count == 2
+    assert abs((window_response.mean or 0) - 1.5) < 1e-6
+
+    write_response = asyncio_run(
+        engine.write_point(WritePointRequest(target="sensors", measurement="env", fields={"temperature": 22.0}))
+    )
+    assert write_response.ok
+
+    resource_text = asyncio_run(engine.read_resource("influxdb://sensors/env?field=temperature&start=-1h"))
+    assert "Consulta InfluxDB" in resource_text
+
+    resources = asyncio_run(engine.list_resources(limit=1))
+    assert resources.items
+
+
+def asyncio_run(coro):
+    return asyncio.run(coro)


### PR DESCRIPTION
## Summary
- create the `influx-mcp` Python package with configuration loading, dual InfluxDB v1/v2 client abstraction, and MCP server startup entrypoint
- implement query orchestration, schemas, utilities, and manifest/resources for MCP tools and influxdb:// resources
- document installation/configuration and add smoke/unit tests for configuration, parsing, and tool behaviors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1c125f80083259735cd81ea533456